### PR TITLE
Update NistTechPubs test

### DIFF
--- a/spec/nist_pubid/nist_tech_pubs_spec.rb
+++ b/spec/nist_pubid/nist_tech_pubs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Pubid::Nist::NistTechPubs, vcr: true do
                     "NIST SP 1800-15",
                     "NIST SP 1265",
                     "NBS FIPS 83",
-                    "NISTIR 8379")
+                    "NIST IR 8379")
     end
 
     it "fetches doi identifiers" do


### PR DESCRIPTION
There are tests failing: https://github.com/metanorma/pubid-nist/actions/runs/5947585927/job/16129888190

Because of identifiers update: `NISTIR 8379` became `NIST IR 8379`