### PR TITLE
Move edition to the end of identifier for long format output

### DIFF
--- a/lib/pubid/nist/renderer/base.rb
+++ b/lib/pubid/nist/renderer/base.rb
@@ -14,9 +14,9 @@ module Pubid::Nist
           "%{supplement}%{section}%{appendix}%{errata}%{index}%{insert}%{update}"\
           "%{stage}%{translation}" % params
         else
-          "%{series}%{code}%{stage}%{volume}%{part}%{edition}%{revision}%{version}"\
+          "%{series}%{code}%{stage}%{volume}%{part}%{revision}%{version}"\
           "%{supplement}%{section}%{appendix}%{errata}%{index}%{insert}%{update}"\
-          "%{translation}" % params
+          "%{edition}%{translation}" % params
         end
       end
 

--- a/spec/nist_pubid/create_spec.rb
+++ b/spec/nist_pubid/create_spec.rb
@@ -28,7 +28,13 @@ module Pubid::Nist
           end
         end
 
-        context "edition with sequence"
+        context "with edition year" do
+          let(:params) { { edition_year: 2021, update: Update.new(number: 5) } }
+
+          it "returns edition at the end of identifier" do
+            expect(subject.to_s(:long)).to eq("National Institute of Standards and Technology Special Publication 123 Update 5 (2021)")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
closes #228 